### PR TITLE
fix #24

### DIFF
--- a/apicompat.go
+++ b/apicompat.go
@@ -109,11 +109,9 @@ func (c *Checker) Check(rel string, recurse bool, beforeRev, afterRev string) ([
 	// Parse revisions from VCS into go/ast
 	start := time.Now()
 	if c.b, err = c.parse(beforeRev); err != nil {
-		fmt.Println("fdsa")
 		return nil, err
 	}
 	if c.a, err = c.parse(afterRev); err != nil {
-		fmt.Println("asdf")
 		return nil, err
 	}
 	parse := time.Since(start)

--- a/apicompat_test.go
+++ b/apicompat_test.go
@@ -32,7 +32,7 @@ func TestParse(t *testing.T) {
 	// Run checks
 	c := New(SetVCS(vcs))
 
-	changes, err := c.Check("", "rev1", "rev2")
+	changes, err := c.Check("", false, "rev1", "rev2")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -114,13 +114,13 @@ func TestPaths(t *testing.T) {
 			t.Errorf("Cannot chdir: %s", err)
 		}
 
-		git, err := NewGit()
+		git, err := NewGit(".")
 		if err != nil {
 			t.Errorf("Cannot get new git: %s", err)
 		}
 		checker := New(SetVCS(git))
 
-		changes, err := checker.Check(test.path, "HEAD~1", "HEAD")
+		changes, err := checker.Check(test.path, false, "HEAD~1", "HEAD")
 		if err != nil {
 			t.Errorf("Check error: %s", err)
 		}

--- a/cmd/apicompat/main.go
+++ b/cmd/apicompat/main.go
@@ -18,9 +18,14 @@ func main() {
 	verbose := flag.Bool("v", false, "Enable verbose logging")
 	flag.Parse()
 	path := flag.Arg(0)
+	rel, rec, err := apicompat.RelativePathToTarget(path)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
 
 	// TODO make it auto discover
-	git, err := apicompat.NewGit()
+	git, err := apicompat.NewGit(rel)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "apicompat: %s\n", err)
 		os.Exit(2)
@@ -38,7 +43,7 @@ func main() {
 	}
 
 	checker := apicompat.New(args...)
-	changes, err := checker.Check(path, *before, *after)
+	changes, err := checker.Check(rel, rec, *before, *after)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "apicompat: %s\n", err)
 		os.Exit(1)

--- a/vcs.go
+++ b/vcs.go
@@ -38,9 +38,9 @@ type Git struct {
 }
 
 // NewGit returns a VCS based based on git.
-func NewGit() (*Git, error) {
+func NewGit(path string) (*Git, error) {
 	// Find the directory of .git, assumes git can find it via cwd
-	dir, err := exec.Command("git", "rev-parse", "--show-toplevel").Output()
+	dir, err := exec.Command("git", "-C", path, "rev-parse", "--show-toplevel").Output()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
```
:) bar$ apicompat 
HEAD:github.com/hydroflame/foo/bar/b.go:3: breaking change declaration removed
	type T struct{}

:) bar$ apicompat ./...
HEAD:github.com/hydroflame/foo/bar/b.go:3: breaking change declaration removed
	type T struct{}

:) bar$ apicompat ../...
HEAD:github.com/hydroflame/foo/bar/b.go:3: breaking change declaration removed
	type T struct{}

:) bar$ cd && apicompat github.com/hydroflame/foo/...
HEAD:github.com/hydroflame/foo/bar/b.go:3: breaking change declaration removed
	type T struct{}

:) ~$ cd && apicompat github.com/hydroflame/foo/bar
HEAD:github.com/hydroflame/foo/bar/b.go:3: breaking change declaration removed
	type T struct{}
```

package github.com/hydroflame/foo/bar is a random package containing a single change since it's last commit, and it seems to be detected every possible way now