### PR TITLE
Line Number Fixups

### DIFF
--- a/apicompat_test.go
+++ b/apicompat_test.go
@@ -8,7 +8,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"reflect"
-	"regexp"
 	"testing"
 )
 
@@ -37,11 +36,10 @@ func TestParse(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	lineNum := regexp.MustCompile(":[0-9]+:")
 	// Save results to buffer for comparison with gold master
 	var buf bytes.Buffer
 	for _, change := range changes {
-		fmt.Fprint(&buf, lineNum.ReplaceAllString(change.String(), ":-:"))
+		fmt.Fprint(&buf, change)
 	}
 
 	// Overwrite the gold master with go test -args update

--- a/ast.go
+++ b/ast.go
@@ -162,10 +162,10 @@ func (c DeclChecker) checkInterface(before, after *ast.InterfaceType, allowRemov
 	r := c.diffFields(keyOnName, before.Methods.List, after.Methods.List)
 	if r.Added() {
 		// Fields were added
-		return breaking("members added", after.Pos()), nil
+		return breaking("members added", r.AddedPos()), nil
 	} else if r.Modified() {
 		// Fields changed types
-		return breaking("members changed types", after.Pos()), nil
+		return breaking("members changed types", r.ModifiedPos()), nil
 	} else if r.Removed() {
 		if allowRemoval {
 			return nonBreaking("members removed", after.Pos()), nil
@@ -209,9 +209,9 @@ func (c DeclChecker) checkStruct(before, after *ast.StructType) (DeclChange, err
 		return breaking("members removed", after.Pos()), nil
 	} else if r.Modified() {
 		// Fields changed types
-		return breaking("members changed types", after.Pos()), nil
+		return breaking("members changed types", r.ModifiedPos()), nil
 	} else if r.Added() {
-		return nonBreaking("members added", after.Pos()), nil
+		return nonBreaking("members added", r.AddedPos()), nil
 	}
 	return none(), nil
 }
@@ -275,6 +275,10 @@ func (d diffResult) Changed() bool {
 func (d diffResult) Added() bool    { return len(d.added) > 0 }
 func (d diffResult) Removed() bool  { return len(d.removed) > 0 }
 func (d diffResult) Modified() bool { return len(d.modified) > 0 }
+
+// No RemovedPos because the removed element's position will not match the after fileset
+func (d diffResult) AddedPos() token.Pos    { return d.added[len(d.added)-1].Pos() }
+func (d diffResult) ModifiedPos() token.Pos { return d.modified[len(d.modified)-1][1].Pos() }
 
 // RemoveVariadicCompatible removes changes and returns a short msg describing
 // the change if the added, removed and changed fields only represent an

--- a/ast.go
+++ b/ast.go
@@ -22,8 +22,12 @@ const (
 
 // DeclChange represents a single change between 2 revision.
 type DeclChange struct {
+	// Change is the type of change, see None, NonBreaking and Breaking.
 	Change string
-	Msg    string
+	// Msg describes what changed, such as "members added".
+	Msg string
+	// Pos is the position of the change.
+	Pos token.Pos
 }
 
 // DeclChecker takes a list of changes and verifies which, if any, change breaks
@@ -39,13 +43,13 @@ func NewDeclChecker(bi, ai *types.Info) *DeclChecker {
 }
 
 // nonBreaking returns a DeclChange with the non-breaking change type.
-func nonBreaking(msg string) DeclChange { return DeclChange{NonBreaking, msg} }
+func nonBreaking(msg string, pos token.Pos) DeclChange { return DeclChange{NonBreaking, msg, pos} }
 
 // breaking returns a DeclChange with the breaking change type.
-func breaking(msg string) DeclChange { return DeclChange{Breaking, msg} }
+func breaking(msg string, pos token.Pos) DeclChange { return DeclChange{Breaking, msg, pos} }
 
 // none returns a DeclChange with the no change type.
-func none() DeclChange { return DeclChange{None, ""} }
+func none() DeclChange { return DeclChange{None, "", 0} }
 
 // Check compares two declarations and returns the DeclChange associated with
 // that change. For example, comments aren't compared, names of arguments aren't
@@ -55,7 +59,7 @@ func (c DeclChecker) Check(before, after ast.Decl) (DeclChange, error) {
 
 	if reflect.TypeOf(before) != reflect.TypeOf(after) {
 		// Declaration type changed, such as GenDecl to FuncDecl (eg var/const to func)
-		return breaking("changed declaration"), nil
+		return breaking("changed declaration", after.Pos()), nil
 	}
 
 	switch b := before.(type) {
@@ -66,7 +70,7 @@ func (c DeclChecker) Check(before, after ast.Decl) (DeclChange, error) {
 
 		if reflect.TypeOf(b.Specs[0]) != reflect.TypeOf(a.Specs[0]) {
 			// Spec changed, such as ValueSpec to TypeSpec (eg var/const to struct)
-			return breaking("changed spec"), nil
+			return breaking("changed spec", a.Specs[0].Pos()), nil
 		}
 
 		switch bspec := b.Specs[0].(type) {
@@ -81,7 +85,7 @@ func (c DeclChecker) Check(before, after ast.Decl) (DeclChange, error) {
 				// Inferred types from external packages (inc. stdlib) aren't identical
 				// according to types.Identical(), so compare the string representations
 				if btype.String() != atype.String() {
-					return breaking("changed type"), nil
+					return breaking("changed type", atype.Pos()), nil
 				}
 			}
 		case *ast.TypeSpec:
@@ -90,7 +94,7 @@ func (c DeclChecker) Check(before, after ast.Decl) (DeclChange, error) {
 
 			if reflect.TypeOf(bspec.Type) != reflect.TypeOf(aspec.Type) {
 				// Spec change, such as from StructType to InterfaceType or different aliased types
-				return breaking("changed type of value spec"), nil
+				return breaking("changed type of value spec", aspec.Pos()), nil
 			}
 
 			switch btype := bspec.Type.(type) {
@@ -105,7 +109,7 @@ func (c DeclChecker) Check(before, after ast.Decl) (DeclChange, error) {
 				atype := aspec.Type.(*ast.Ident)
 				if btype.Name != atype.Name {
 					// Alias typing changed underlying types
-					return breaking("alias changed its underlying type"), nil
+					return breaking("alias changed its underlying type", atype.Pos()), nil
 				}
 			}
 		}
@@ -120,16 +124,16 @@ func (c DeclChecker) Check(before, after ast.Decl) (DeclChange, error) {
 
 func (c DeclChecker) checkChan(before, after *ast.ChanType) (DeclChange, error) {
 	if !c.exprEqual(before.Value, after.Value) {
-		return breaking("changed channel's type"), nil
+		return breaking("changed channel's type", after.Pos()), nil
 	}
 
 	// If we're specifying a direction and it's not the same as before
 	// (if we remove direction then that change isn't breaking)
 	if before.Dir != after.Dir {
 		if after.Dir != ast.SEND && after.Dir != ast.RECV {
-			return nonBreaking("removed channel's direction"), nil
+			return nonBreaking("removed channel's direction", after.Pos()), nil
 		}
-		return breaking("changed channel's direction"), nil
+		return breaking("changed channel's direction", after.Pos()), nil
 	}
 	return none(), nil
 }
@@ -158,15 +162,15 @@ func (c DeclChecker) checkInterface(before, after *ast.InterfaceType, allowRemov
 	r := c.diffFields(keyOnName, before.Methods.List, after.Methods.List)
 	if r.Added() {
 		// Fields were added
-		return breaking("members added"), nil
+		return breaking("members added", after.Pos()), nil
 	} else if r.Modified() {
 		// Fields changed types
-		return breaking("members changed types"), nil
+		return breaking("members changed types", after.Pos()), nil
 	} else if r.Removed() {
 		if allowRemoval {
-			return nonBreaking("members removed"), nil
+			return nonBreaking("members removed", after.Pos()), nil
 		}
-		return breaking("members removed"), nil
+		return breaking("members removed", after.Pos()), nil
 	}
 
 	return none(), nil
@@ -202,12 +206,12 @@ func (c DeclChecker) checkStruct(before, after *ast.StructType) (DeclChange, err
 	r := c.diffFields(keyOnName, before.Fields.List, after.Fields.List)
 	if r.Removed() {
 		// Fields were removed
-		return breaking("members removed"), nil
+		return breaking("members removed", after.Pos()), nil
 	} else if r.Modified() {
 		// Fields changed types
-		return breaking("members changed types"), nil
+		return breaking("members changed types", after.Pos()), nil
 	} else if r.Added() {
-		return nonBreaking("members added"), nil
+		return nonBreaking("members added", after.Pos()), nil
 	}
 	return none(), nil
 }
@@ -224,13 +228,13 @@ func (c DeclChecker) checkFunc(before, after *ast.FuncType) (DeclChange, error) 
 		return DeclChange{}, err
 	}
 	if r.Changed() {
-		return breaking("parameter types changed"), nil
+		return breaking("parameter types changed", after.Pos()), nil
 	}
 
 	if before.Results != nil {
 		if after.Results == nil {
 			// removed return parameter
-			return breaking("removed return parameter"), nil
+			return breaking("removed return parameter", after.Pos()), nil
 		}
 
 		// don't compare argument names
@@ -242,16 +246,16 @@ func (c DeclChecker) checkFunc(before, after *ast.FuncType) (DeclChange, error) 
 		if len(before.Results.List) > 0 {
 			r := c.diffFields(keyOnPosition, bresults, aresults)
 			if r.Changed() {
-				return breaking("return parameters changed"), nil
+				return breaking("return parameters changed", after.Pos()), nil
 			}
 		}
 	}
 
 	switch {
 	case interfaceMsg != "":
-		return nonBreaking(interfaceMsg), nil
+		return nonBreaking(interfaceMsg, after.Pos()), nil
 	case variadicMsg != "":
-		return nonBreaking(variadicMsg), nil
+		return nonBreaking(variadicMsg, after.Pos()), nil
 	default:
 		return none(), nil
 	}

--- a/testdata/exp.txt
+++ b/testdata/exp.txt
@@ -1,115 +1,115 @@
-rev2:abitest.go:-: breaking change changed type
+rev2:abitest.go:38: breaking change changed type
 	var AliasedImportChange tmpl.Template
 	var AliasedImportChange tmpl.Template
-rev2:abitest.go:-: breaking change members changed types
+rev2:abitest.go:41: breaking change members changed types
 	type AliasedImportChangeS struct{ T tmpl.Template }
 	type AliasedImportChangeS struct{ T tmpl.Template }
-rev2:abitest.go:-: non-breaking change declaration added
+rev2:abitest.go:23: non-breaking change declaration added
 	const ConstAdded int = 0
-rev2:abitest.go:-: breaking change changed type
+rev2:abitest.go:35: breaking change changed type
 	const ConstChangeType int = 0
 	const ConstChangeType uint = 0
-rev2:abitest.go:-: non-breaking change declaration added
+rev2:abitest.go:19: non-breaking change declaration added
 	const ConstMultiSpecB int = 0
-rev1:abitest.go:-: breaking change declaration removed
+rev1:abitest.go:26: breaking change declaration removed
 	const ConstRemoved int = 0
-rev2:abitest.go:-: breaking change parameter types changed
+rev2:abitest.go:251: breaking change parameter types changed
 	func FuncAddArg()
 	func FuncAddArg(arg1 int)
-rev2:abitest.go:-: breaking change return parameters changed
+rev2:abitest.go:272: breaking change return parameters changed
 	func FuncAddRetMore() error
 	func FuncAddRetMore() (error, bool)
-rev2:abitest.go:-: non-breaking change added a variadic parameter
+rev2:abitest.go:290: non-breaking change added a variadic parameter
 	func FuncAddVariadic()
 	func FuncAddVariadic(_ ...int)
-rev2:abitest.go:-: breaking change parameter types changed
+rev2:abitest.go:257: breaking change parameter types changed
 	func FuncChangeArg(arg1 int)
 	func FuncChangeArg(param uint)
-rev2:abitest.go:-: breaking change parameter types changed
+rev2:abitest.go:260: breaking change parameter types changed
 	func FuncChangeChan(arg1 chan int)
 	func FuncChangeChan(arg1 chan uint)
-rev2:abitest.go:-: breaking change parameter types changed
+rev2:abitest.go:263: breaking change parameter types changed
 	func FuncChangeChanDir(arg1 chan int)
 	func FuncChangeChanDir(arg1 <-chan int)
-rev2:abitest.go:-: breaking change return parameters changed
+rev2:abitest.go:278: breaking change return parameters changed
 	func FuncChangeRet() error
 	func FuncChangeRet() bool
-rev2:abitest.go:-: breaking change return parameters changed
+rev2:abitest.go:279: breaking change return parameters changed
 	func FuncChangeRetStarIdent() *int
 	func FuncChangeRetStarIdent() *uint
-rev2:abitest.go:-: breaking change return parameters changed
+rev2:abitest.go:280: breaking change return parameters changed
 	func FuncChangeRetStarSelector() *bytes.Buffer
 	func FuncChangeRetStarSelector() *bytes.Reader
-rev2:abitest.go:-: non-breaking change change parameter to variadic
+rev2:abitest.go:293: non-breaking change change parameter to variadic
 	func FuncChangeToVariadic(_ int)
 	func FuncChangeToVariadic(_ ...int)
-rev2:abitest.go:-: breaking change parameter types changed
+rev2:abitest.go:296: breaking change parameter types changed
 	func FuncChangeToVariadicDiffType(_ int)
 	func FuncChangeToVariadicDiffType(_ ...uint)
-rev2:abitest.go:-: non-breaking change compatible interface change
+rev2:abitest.go:313: non-breaking change compatible interface change
 	func FuncInterfaceCompatible(_ T3)
 	func FuncInterfaceCompatible(_ T1)
-rev2:abitest.go:-: non-breaking change compatible interface change
+rev2:abitest.go:316: non-breaking change compatible interface change
 	func FuncInterfaceCompatible2(_ io.WriteCloser)
 	func FuncInterfaceCompatible2(_ io.Writer)
-rev2:abitest.go:-: non-breaking change compatible interface change
+rev2:abitest.go:319: non-breaking change compatible interface change
 	func FuncInterfaceCompatible3(_ T2)
 	func FuncInterfaceCompatible3(_ error)
-rev2:abitest.go:-: breaking change parameter types changed
+rev2:abitest.go:310: breaking change parameter types changed
 	func FuncInterfaceIncompatible(_ T1)
 	func FuncInterfaceIncompatible(_ T3)
-rev2:abitest.go:-: breaking change parameter types changed
+rev2:abitest.go:285: breaking change parameter types changed
 	func (_ *FuncRecv) Method1(arg1 int) (ret1 error)
 	func (_ *FuncRecv) Method1(arg1 bool) (ret1 int)
-rev2:abitest.go:-: breaking change parameter types changed
+rev2:abitest.go:286: breaking change parameter types changed
 	func (_ FuncRecv) Method2(arg1 int) (ret1 error)
 	func (_ FuncRecv) Method2(arg1 bool) (ret1 int)
-rev2:abitest.go:-: breaking change parameter types changed
+rev2:abitest.go:254: breaking change parameter types changed
 	func FuncRemArg(arg1 int)
 	func FuncRemArg()
-rev2:abitest.go:-: breaking change removed return parameter
+rev2:abitest.go:275: breaking change removed return parameter
 	func FuncRemRet() error
 	func FuncRemRet()
-rev2:abitest.go:-: breaking change changed spec
+rev2:abitest.go:32: breaking change changed spec
 	const GenDeclSpecChange int = 1
 	type GenDeclSpecChange struct{}
-rev2:abitest.go:-: breaking change changed declaration
+rev2:abitest.go:29: breaking change changed declaration
 	const GenFuncDeclChange int = 1
 	func GenFuncDeclChange()
-rev2:abitest.go:-: breaking change members added
+rev2:abitest.go:209: breaking change members added
 	type IfaceAddMember interface{}
 	type IfaceAddMember interface {
 		Member1(arg1 int) (ret1 bool)
 	}
-rev2:abitest.go:-: breaking change members changed types
+rev2:abitest.go:224: breaking change members changed types
 	type IfaceChangeMemberArg interface {
 		Member1(arg1 int) (ret1 bool)
 	}
 	type IfaceChangeMemberArg interface {
 		Member1(arg1 uint) (ret1 bool)
 	}
-rev2:abitest.go:-: breaking change members changed types
+rev2:abitest.go:229: breaking change members changed types
 	type IfaceChangeMemberReturn interface {
 		Member1(arg1 int) (ret1 bool)
 	}
 	type IfaceChangeMemberReturn interface {
 		Member1(arg1 int) (ret1 int)
 	}
-rev2:abitest.go:-: breaking change members removed
+rev2:abitest.go:214: breaking change members removed
 	type IfaceRemMember interface {
 		Member1(arg1 int) (ret1 bool)
 	}
 	type IfaceRemMember interface{}
-rev2:abitest.go:-: non-breaking change members added
+rev2:abitest.go:135: non-breaking change members added
 	type StructAddMember struct{}
 	type StructAddMember struct {
 		Member1	int
 		Member2	[]int
 	}
-rev2:abitest.go:-: breaking change members changed types
+rev2:abitest.go:166: breaking change members changed types
 	type StructChangeMember struct{ Member1 int }
 	type StructChangeMember struct{ Member1 uint }
-rev2:abitest.go:-: non-breaking change members added
+rev2:abitest.go:144: non-breaking change members added
 	type StructEmbedAddMember struct {
 		Struct
 		*StructPtr
@@ -123,81 +123,81 @@ rev2:abitest.go:-: non-breaking change members added
 		bytes.Buffer
 		*bytes.Reader
 	}
-rev2:abitest.go:-: breaking change members removed
+rev2:abitest.go:154: breaking change members removed
 	type StructRemEmbed struct{ Struct }
 	type StructRemEmbed struct{}
-rev2:abitest.go:-: breaking change members removed
+rev2:abitest.go:149: breaking change members removed
 	type StructRemMember struct{ Member1 int }
 	type StructRemMember struct{}
-rev2:abitest.go:-: breaking change alias changed its underlying type
+rev2:abitest.go:232: breaking change alias changed its underlying type
 	type TypeAlias int
 	type TypeAlias uint
-rev2:abitest.go:-: breaking change changed type of value spec
+rev2:abitest.go:121: breaking change changed type of value spec
 	type TypeSpecChange struct{}
 	type TypeSpecChange interface{}
-rev2:abitest.go:-: breaking change changed type
+rev2:abitest.go:51: breaking change changed type
 	var ValChangeMulti = 1
 	var ValChangeMulti = false
-rev2:abitest.go:-: breaking change changed type
+rev2:abitest.go:50: breaking change changed type
 	var ValChangeMultiZeroState int
 	var ValChangeMultiZeroState uint
-rev2:abitest.go:-: breaking change changed type
+rev2:abitest.go:90: breaking change changed type
 	var VarAddTypeFuncResult func(int)
 	var VarAddTypeFuncResult func(int) error
-rev2:abitest.go:-: breaking change changed type
+rev2:abitest.go:54: breaking change changed type
 	var VarChangeType int
 	var VarChangeType uint
-rev2:abitest.go:-: breaking change changed type
+rev2:abitest.go:102: breaking change changed type
 	var VarChangeTypeArrayLen [1]int
 	var VarChangeTypeArrayLen [2]int
-rev2:abitest.go:-: breaking change changed type
+rev2:abitest.go:105: breaking change changed type
 	var VarChangeTypeArrayType [1]int
 	var VarChangeTypeArrayType [1]uint
-rev2:abitest.go:-: breaking change changed type
+rev2:abitest.go:66: breaking change changed type
 	var VarChangeTypeChan chan int
 	var VarChangeTypeChan chan uint
-rev2:abitest.go:-: breaking change changed type
+rev2:abitest.go:69: breaking change changed type
 	var VarChangeTypeChanDir chan int
 	var VarChangeTypeChanDir <-chan int
-rev2:abitest.go:-: breaking change changed type
+rev2:abitest.go:72: breaking change changed type
 	var VarChangeTypeChanDirRelax <-chan int
 	var VarChangeTypeChanDirRelax chan int
-rev2:abitest.go:-: breaking change changed type
+rev2:abitest.go:84: breaking change changed type
 	var VarChangeTypeFuncParam func(int) error
 	var VarChangeTypeFuncParam func(uint) error
-rev2:abitest.go:-: breaking change changed type
+rev2:abitest.go:87: breaking change changed type
 	var VarChangeTypeFuncResult func(int) error
 	var VarChangeTypeFuncResult func(int) bool
-rev2:abitest.go:-: breaking change changed type
+rev2:abitest.go:108: breaking change changed type
 	var VarChangeTypeMapKey map[int]int
 	var VarChangeTypeMapKey map[uint]int
-rev2:abitest.go:-: breaking change changed type
+rev2:abitest.go:111: breaking change changed type
 	var VarChangeTypeMapValue map[int]int
 	var VarChangeTypeMapValue map[int]uint
-rev2:abitest.go:-: breaking change changed type
+rev2:abitest.go:114: breaking change changed type
 	var VarChangeTypeSelector bytes.Buffer
 	var VarChangeTypeSelector bytes.Reader
-rev2:abitest.go:-: breaking change changed type
+rev2:abitest.go:96: breaking change changed type
 	var VarChangeTypeSlice []int
 	var VarChangeTypeSlice []uint
-rev2:abitest.go:-: breaking change changed type
+rev2:abitest.go:99: breaking change changed type
 	var VarChangeTypeSliceLen []int
 	var VarChangeTypeSliceLen [1]int
-rev2:abitest.go:-: breaking change changed type
+rev2:abitest.go:117: breaking change changed type
 	var VarChangeTypeStar *int
 	var VarChangeTypeStar *uint
-rev2:abitest.go:-: breaking change changed type
+rev2:abitest.go:118: breaking change changed type
 	var VarChangeTypeStarSelector *bytes.Buffer
 	var VarChangeTypeStarSelector *bytes.Reader
-rev2:abitest.go:-: breaking change changed type
+rev2:abitest.go:57: breaking change changed type
 	var VarChangeValSpecType int
 	var VarChangeValSpecType []int
-rev2:abitest.go:-: breaking change changed type
+rev2:abitest.go:93: breaking change changed type
 	var VarRemoveTypeFuncResult func(int) error
 	var VarRemoveTypeFuncResult func(int)
-rev2:abitest.go:-: breaking change members changed types
+rev2:abitest.go:327: breaking change members changed types
 	type s struct{ Member int }
 	type s struct{ Member uint }
-rev2:abitest.go:-: breaking change return parameters changed
+rev2:abitest.go:331: breaking change return parameters changed
 	func (s) F() int
 	func (s) F() uint

--- a/testdata/exp.txt
+++ b/testdata/exp.txt
@@ -76,19 +76,19 @@ rev2:abitest.go:32: breaking change changed spec
 rev2:abitest.go:29: breaking change changed declaration
 	const GenFuncDeclChange int = 1
 	func GenFuncDeclChange()
-rev2:abitest.go:207: breaking change members added
+rev2:abitest.go:208: breaking change members added
 	type IfaceAddMember interface{}
 	type IfaceAddMember interface {
 		Member1(arg1 int) (ret1 bool)
 	}
-rev2:abitest.go:222: breaking change members changed types
+rev2:abitest.go:223: breaking change members changed types
 	type IfaceChangeMemberArg interface {
 		Member1(arg1 int) (ret1 bool)
 	}
 	type IfaceChangeMemberArg interface {
 		Member1(arg1 uint) (ret1 bool)
 	}
-rev2:abitest.go:227: breaking change members changed types
+rev2:abitest.go:228: breaking change members changed types
 	type IfaceChangeMemberReturn interface {
 		Member1(arg1 int) (ret1 bool)
 	}
@@ -100,16 +100,16 @@ rev2:abitest.go:212: breaking change members removed
 		Member1(arg1 int) (ret1 bool)
 	}
 	type IfaceRemMember interface{}
-rev2:abitest.go:132: non-breaking change members added
+rev2:abitest.go:134: non-breaking change members added
 	type StructAddMember struct{}
 	type StructAddMember struct {
 		Member1	int
 		Member2	[]int
 	}
-rev2:abitest.go:164: breaking change members changed types
+rev2:abitest.go:165: breaking change members changed types
 	type StructChangeMember struct{ Member1 int }
 	type StructChangeMember struct{ Member1 uint }
-rev2:abitest.go:138: non-breaking change members added
+rev2:abitest.go:139: non-breaking change members added
 	type StructEmbedAddMember struct {
 		Struct
 		*StructPtr

--- a/testdata/exp.txt
+++ b/testdata/exp.txt
@@ -76,40 +76,40 @@ rev2:abitest.go:32: breaking change changed spec
 rev2:abitest.go:29: breaking change changed declaration
 	const GenFuncDeclChange int = 1
 	func GenFuncDeclChange()
-rev2:abitest.go:209: breaking change members added
+rev2:abitest.go:207: breaking change members added
 	type IfaceAddMember interface{}
 	type IfaceAddMember interface {
 		Member1(arg1 int) (ret1 bool)
 	}
-rev2:abitest.go:224: breaking change members changed types
+rev2:abitest.go:222: breaking change members changed types
 	type IfaceChangeMemberArg interface {
 		Member1(arg1 int) (ret1 bool)
 	}
 	type IfaceChangeMemberArg interface {
 		Member1(arg1 uint) (ret1 bool)
 	}
-rev2:abitest.go:229: breaking change members changed types
+rev2:abitest.go:227: breaking change members changed types
 	type IfaceChangeMemberReturn interface {
 		Member1(arg1 int) (ret1 bool)
 	}
 	type IfaceChangeMemberReturn interface {
 		Member1(arg1 int) (ret1 int)
 	}
-rev2:abitest.go:214: breaking change members removed
+rev2:abitest.go:212: breaking change members removed
 	type IfaceRemMember interface {
 		Member1(arg1 int) (ret1 bool)
 	}
 	type IfaceRemMember interface{}
-rev2:abitest.go:135: non-breaking change members added
+rev2:abitest.go:132: non-breaking change members added
 	type StructAddMember struct{}
 	type StructAddMember struct {
 		Member1	int
 		Member2	[]int
 	}
-rev2:abitest.go:166: breaking change members changed types
+rev2:abitest.go:164: breaking change members changed types
 	type StructChangeMember struct{ Member1 int }
 	type StructChangeMember struct{ Member1 uint }
-rev2:abitest.go:144: non-breaking change members added
+rev2:abitest.go:138: non-breaking change members added
 	type StructEmbedAddMember struct {
 		Struct
 		*StructPtr
@@ -123,10 +123,10 @@ rev2:abitest.go:144: non-breaking change members added
 		bytes.Buffer
 		*bytes.Reader
 	}
-rev2:abitest.go:154: breaking change members removed
+rev2:abitest.go:152: breaking change members removed
 	type StructRemEmbed struct{ Struct }
 	type StructRemEmbed struct{}
-rev2:abitest.go:149: breaking change members removed
+rev2:abitest.go:147: breaking change members removed
 	type StructRemMember struct{ Member1 int }
 	type StructRemMember struct{}
 rev2:abitest.go:232: breaking change alias changed its underlying type


### PR DESCRIPTION
See commit for more details, but essentially these three commits helps to report the exact line that changed, instead of the declarations line number (and in some cases the end of the declaration).

Note, for a struct field or interface method that's been removed the line number is that of the type declaration, because the member has been removed, it no longer has a suitable name. Alternatively we could've chosen the end of the declaration, I think either would've been fine.